### PR TITLE
fix: SITES-13731 ignore techacct.adobe.com for notifications

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -123,7 +123,7 @@ export async function sendSlackMessage(slackToken, channelId, message) {
 }
 
 export function isValidEmail(email) {
-  return /^[^@]+@[^@]+$/.test(email);
+  return /^[^@]+@[^@]+$/.test(email) && !email.endsWith('@techacct.adobe.com');
 }
 
 export function isValidRelPath(relPath) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -280,6 +280,7 @@ describe('Utils Tests', () => {
     assert.strictEqual(isValidEmail(), false);
     assert.strictEqual(isValidEmail('a'), false);
     assert.strictEqual(isValidEmail('a@b'), true);
+    assert.strictEqual(isValidEmail('a@techacct.adobe.com'), false);
   });
   it('createConversation cases', async () => {
     assert.strictEqual(await createConversation(null, 'invalid'), null);


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

While implementing better notifications for SITES-13731. A few type of notifications can be ignored as those are generally generated by techacct.adobe.com (integration tokens) 

Thanks for contributing!
